### PR TITLE
feat: main page new beta look with example content

### DIFF
--- a/src/data/MainPageDataContent.ts
+++ b/src/data/MainPageDataContent.ts
@@ -1,0 +1,52 @@
+import { MainPageDataContent } from "../types/MainPageDataContent";
+
+export const mainPageDataContent: MainPageDataContent[] = [
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+    {
+        cartTitle: "Example Cart Title",
+        cartContent:
+            "Example Content. Example Content. Example Content. Example Content. Example Content.",
+        buttonName: "Example Button",
+    },
+];

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -4,7 +4,7 @@ export const Footer = () => {
     return (
         <div className="card">
             <div className="card-body">
-                <p className="card-text footer">
+                <p className="card-text footer container">
                     GitHub 2023 - Designed and implemented by @pawelnu & @grz55
                 </p>
             </div>

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,12 +1,15 @@
-import "./../static/styles/Footer.css"
+import "./../static/styles/Footer.css";
 
 export const Footer = () => {
     return (
-        <div className="card">
-            <div className="card-body">
-                <p className="card-text footer container">
-                    GitHub 2023 - Designed and implemented by @pawelnu & @grz55
-                </p>
+        <div className="container px-1">
+            <div className="card">
+                <div className="card-body">
+                    <p className="card-text footer">
+                        GitHub 2023 - Designed and implemented by @pawelnu &
+                        @grz55
+                    </p>
+                </div>
             </div>
         </div>
     );

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -2,14 +2,11 @@ import "./../static/styles/Footer.css";
 
 export const Footer = () => {
     return (
-        <div className="container px-1">
-            <div className="card">
-                <div className="card-body">
-                    <p className="card-text footer">
-                        GitHub 2023 - Designed and implemented by @pawelnu &
-                        @grz55
-                    </p>
-                </div>
+        <div className="card">
+            <div className="card-body">
+                <p className="card-text footer text-center">
+                    GitHub 2023 - Designed and implemented by @pawelnu & @grz55
+                </p>
             </div>
         </div>
     );

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -3,41 +3,46 @@ import "./../static/styles/Navbar.css";
 export const Navbar = () => {
     return (
         <nav className="navbar navbar-expand-lg navbar-custom mt-2">
-            <div className="container-fluid">
-                <button
-                    className="navbar-toggler"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#navBar"
-                    aria-controls="navBar"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation"
-                >
-                    <span className="navbar-toggler-icon"></span>
-                </button>
-                <div className="collapse navbar-collapse" id="navBar">
-                    <ul className="navbar-nav">
-                        <li className="nav-item">
-                            <a className="nav-link active text-red" href="/">
-                                Promotions and more
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                Loan installment
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                Returns and complaints
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                Contact
-                            </a>
-                        </li>
-                    </ul>
+            <div className="container px-0">
+                <div className="container-fluid px-0">
+                    <button
+                        className="navbar-toggler"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#navBar"
+                        aria-controls="navBar"
+                        aria-expanded="false"
+                        aria-label="Toggle navigation"
+                    >
+                        <span className="navbar-toggler-icon"></span>
+                    </button>
+                    <div className="collapse navbar-collapse" id="navBar">
+                        <ul className="navbar-nav">
+                            <li className="nav-item">
+                                <a
+                                    className="nav-link active text-red"
+                                    href="/"
+                                >
+                                    Promotions and more
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    Loan installment
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    Returns and complaints
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    Contact
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </nav>

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -1,8 +1,8 @@
-import "./../static/styles/CategoryBar.css";
+import "./../static/styles/Navbar.css";
 
 export const Navbar = () => {
     return (
-        <nav className="navbar navbar-expand-lg category-bar mt-2">
+        <nav className="navbar navbar-expand-lg navbar-custom mt-2">
             <div className="container-fluid">
                 <button
                     className="navbar-toggler"

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,25 +1,30 @@
 import { Link } from "react-router-dom";
 import { CategoryBar } from "./components/CategoryBar";
 import { Navbar } from "../../layout/Navbar";
+import { MainPageContentExample } from "./components/MainPageContentExample";
 
 export const MainPage = () => {
     return (
         <div className="m-2">
             <div>
-                <Navbar/>
+                <Navbar />
             </div>
-            <h1>TODO Main Page</h1>
+
             <div>
                 <Link to="/">
-                <img
-                    src={require("./../../images/store_logo.png")}
-                    alt="Logo"
-                    width={300}
-                />
+                    <img
+                        src={require("./../../images/store_logo.png")}
+                        alt="Logo"
+                        width={300}
+                    />
                 </Link>
             </div>
+            <div>Welcome to CompStore. The best devices just for you!</div>
             <div>
                 <CategoryBar />
+            </div>
+            <div>
+                <MainPageContentExample />
             </div>
         </div>
     );

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,32 +1,19 @@
-import { Link } from "react-router-dom";
 import { CategoryBar } from "./components/CategoryBar";
 import { Navbar } from "../../layout/Navbar";
 import { MainPageContentExample } from "./components/MainPageContentExample";
 import { Footer } from "../../layout/Footer";
+import { Baner } from "./components/Baner";
 
 export const MainPage = () => {
     return (
         <div className="m-2">
-            <div>
-                <Navbar />
+            <Navbar />
+            <Baner />
+            <CategoryBar />
+            <div className="container p-2">
+                Welcome to CompStore. The best devices just for you!
             </div>
-
-            <div>
-                <Link to="/">
-                    <img
-                        src={require("./../../images/store_logo.png")}
-                        alt="Logo"
-                        width={300}
-                    />
-                </Link>
-            </div>
-            <div>Welcome to CompStore. The best devices just for you!</div>
-            <div>
-                <CategoryBar />
-            </div>
-            <div>
-                <MainPageContentExample />
-            </div>
+            <MainPageContentExample />
             <div>
                 <Footer />
             </div>

--- a/src/pages/MainPage/components/Baner.tsx
+++ b/src/pages/MainPage/components/Baner.tsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router-dom";
+
+export const Baner = () => {
+    return (
+        <div className="container mt-2">
+            <Link to={"/"}>
+                <img
+                    src={require("./../../../images/store_logo.png")}
+                    alt="Logo"
+                    width={300}
+                />
+            </Link>
+        </div>
+    );
+};

--- a/src/pages/MainPage/components/CategoryBar.tsx
+++ b/src/pages/MainPage/components/CategoryBar.tsx
@@ -4,9 +4,6 @@ export const CategoryBar = () => {
     return (
         <nav className="navbar navbar-expand-lg category-bar mt-2">
             <div className="container-fluid">
-                <a className="navbar-brand" href="/">
-                    Categories
-                </a>
                 <button
                     className="navbar-toggler"
                     type="button"

--- a/src/pages/MainPage/components/CategoryBar.tsx
+++ b/src/pages/MainPage/components/CategoryBar.tsx
@@ -3,41 +3,46 @@ import "./../../../static/styles/CategoryBar.css";
 export const CategoryBar = () => {
     return (
         <nav className="navbar navbar-expand-lg category-bar mt-2">
-            <div className="container-fluid">
-                <button
-                    className="navbar-toggler"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#categoryBar"
-                    aria-controls="categoryBar"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation"
-                >
-                    <span className="navbar-toggler-icon"></span>
-                </button>
-                <div className="collapse navbar-collapse" id="categoryBar">
-                    <ul className="navbar-nav">
-                        <li className="nav-item">
-                            <a className="nav-link active text-red" href="/">
-                                PCs
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                Laptops
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                Smartphones
-                            </a>
-                        </li>
-                        <li className="nav-item">
-                            <a className="nav-link active" href="/">
-                                TVs
-                            </a>
-                        </li>
-                    </ul>
+            <div className="container px-0">
+                <div className="container-fluid px-0">
+                    <button
+                        className="navbar-toggler"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#categoryBar"
+                        aria-controls="categoryBar"
+                        aria-expanded="false"
+                        aria-label="Toggle navigation"
+                    >
+                        <span className="navbar-toggler-icon"></span>
+                    </button>
+                    <div className="collapse navbar-collapse" id="categoryBar">
+                        <ul className="navbar-nav">
+                            <li className="nav-item">
+                                <a
+                                    className="nav-link active text-red"
+                                    href="/"
+                                >
+                                    PCs
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    Laptops
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    Smartphones
+                                </a>
+                            </li>
+                            <li className="nav-item">
+                                <a className="nav-link active" href="/">
+                                    TVs
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </nav>

--- a/src/pages/MainPage/components/MainPageContentExample.tsx
+++ b/src/pages/MainPage/components/MainPageContentExample.tsx
@@ -1,0 +1,27 @@
+import { mainPageDataContent } from "../../../data/MainPageDataContent";
+
+export const MainPageContentExample = () => {
+    return (
+        <div className="container p-2 mb-2">
+            <div className="row">
+                {mainPageDataContent.map((data, index) => (
+                <div key={index + 1} className="col-sm-6 mb-2">
+                    <div className="card">
+                        <div className="card-body">
+                            <h5 className="card-title">
+                                {data.cartTitle}
+                            </h5>
+                            <p className="card-text">
+                                {data.cartContent}
+                            </p>
+                            <a href="/" className="btn btn-primary">
+                                {data.buttonName}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/static/styles/CategoryBar.css
+++ b/src/static/styles/CategoryBar.css
@@ -1,3 +1,4 @@
 .category-bar {
     background-color: #e3f2fd;
+    font-weight: 700;
 }

--- a/src/static/styles/Navbar.css
+++ b/src/static/styles/Navbar.css
@@ -1,0 +1,4 @@
+.navbar-custom {
+    background-color: #e3f2fd;
+    font-size: 14px;
+}

--- a/src/types/MainPageDataContent.ts
+++ b/src/types/MainPageDataContent.ts
@@ -1,0 +1,5 @@
+export type MainPageDataContent = {
+    cartTitle: string;
+    cartContent: string;
+    buttonName: string;
+};


### PR DESCRIPTION
https://trello.com/c/VxbebXdD/35-f-ustalenie-wygl%C4%85du-wersji-beta-strony-g%C5%82%C3%B3wnej

Czcionka w `Promotions` zmniejszona.

Treść strony zajmuje mniej więcej 75%.

![image](https://github.com/pawelNu/compstore-ui/assets/93542936/a1e54cab-1877-40cf-8d38-573b39986fcf)

`TODO Main Page` i `Categories` usunięte.

`Welcome to CompStore. The best devices just for you!` dodane.

![image](https://github.com/pawelNu/compstore-ui/assets/93542936/c5d03b15-59cc-4a5b-a2be-68b37a0cbadc)

Jak zachowuje się treść strony przy różnych szerokościach?

Pełna szerokość.

![image](https://github.com/pawelNu/compstore-ui/assets/93542936/72e6ed55-6671-4325-9fe6-8f90647717f6)

Mniejsza szerokość - navbar i category bar się zwijają, treść strony się z zwęża ale pozostaje w 2 kolumnach.

![image](https://github.com/pawelNu/compstore-ui/assets/93542936/fe3f8603-e986-4d47-a04e-4789cf3b4ba6)

Maksymalnie zawężone - navbar i category bar się zwijają, treść strony się z zwęża do 1 kolumny.

![image](https://github.com/pawelNu/compstore-ui/assets/93542936/79588bec-5278-48e8-bb84-7ac5baab0918)

W żadnym przypadku nie ma paska przewijania w lewo-prawo.